### PR TITLE
fixed broken links for metalabel reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@
 
 ### February 2023
 
-- [Metalabel - NFT Collections Releasing](./reports/Metalabel-Solo-Security-Review.md)
-- [Metalabel - NFT Collections Releasing, V1.1](./reports/Metalabel-V1_1-Solo-Security-Review.md)
+- [Metalabel - NFT Collections Releasing](./reports/Metalabel-Security-Review.md)
+- [Metalabel - NFT Collections Releasing, V1.1](./reports/Metalabel-V1_1-Security-Review.md)
 
 ## Bug bounty
 


### PR DESCRIPTION
The links to both Metalabel reports were broken and produced a 404 error.
Both reports are present in the /audits directory but the file names are incorrect. 